### PR TITLE
qcom: power: Stop log spam "QCOM PowerHAL: Failed to acquire lock

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -279,7 +279,7 @@ int perf_hint_enable_with_type(int hint_id, int duration, int type)
         if (perf_hint) {
             lock_handle = perf_hint(hint_id, NULL, duration, type);
             if (lock_handle == -1)
-                ALOGE("Failed to acquire lock.");
+                ALOGV("Failed to acquire lock.");
         }
     }
     return lock_handle;


### PR DESCRIPTION
Change-Id: Iadd2ddc3df316d1692b5dad528405c0a8b5bf4b3
Signed-off-by: Dusan Uveric <dusan.uveric9@gmail.com>